### PR TITLE
Modify the configurations for the elk node

### DIFF
--- a/modules/cibook_project/files/logstash/jenkins-log-client.yaml
+++ b/modules/cibook_project/files/logstash/jenkins-log-client.yaml
@@ -12,9 +12,3 @@ source-files:
     retry-get: True
     tags:
       - console
-  - name: logs/syslog.txt
-    tags:
-      - syslog
-  - name: logs/libvirtd.txt
-    tags:
-      - libvirt

--- a/modules/cibook_project/manifests/elasticsearch_node.pp
+++ b/modules/cibook_project/manifests/elasticsearch_node.pp
@@ -16,7 +16,7 @@
 #
 class cibook_project::elasticsearch_node (
   $discover_nodes = ['localhost'],
-  $heap_size = '10g',
+  $heap_size = '4g',
 ) {
   class { 'logstash::elasticsearch': }
 


### PR DESCRIPTION
- syslog.txt and libvirtd.txt don't exist in log server, no need to
fetch them
- change the elasticsearch's heap size

Signed-off-by: zhihui wu <wu.zhihui1@zte.com.cn>